### PR TITLE
Fix for ndarray error on submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.DS_Store

--- a/qe_minesweeper.py
+++ b/qe_minesweeper.py
@@ -32,6 +32,8 @@ def load_answers(filename,scenario):
 
 def submit_answers(mine_estimates, stage, authkey):
 
+    mine_estimates = serialize_array(mine_estimates)
+
     #creates JSON form data for HTTP request
     payload = {"answers":mine_estimates}
     
@@ -68,3 +70,17 @@ def estimate_check(mine_positions,mine_estimates):
 
 def post_to_server(payload, ref=""):
         return requests.post(URL+ref, json=payload, headers={'QeC':QEC})
+
+def serialize_array(array):
+    print(array)
+    output = []
+    for i in array:
+        print(i)
+        if isinstance(i, np.ndarray):
+            i.tolist()
+            output.append(serialize_array(i))
+        elif isinstance(i, list):
+            output.append(serialize_array(i))
+        else:
+            output.append(i)
+    return output


### PR DESCRIPTION
Python arrays are not absolute, they can contain differing arrays within them, this adds a new function, `serialize_array()` that runs through an array of dynamic structure and serializes it to a list for the purposes of submitting estimates.